### PR TITLE
Impose a minimum limit to amount of steps of 2

### DIFF
--- a/src/imgmin.c
+++ b/src/imgmin.c
@@ -681,6 +681,7 @@ static int parse_opts(int argc, char * const argv[], struct imgmin_options *opt)
         } else if (0 == strcmp("--max-steps", argv[i])) {
             opt->max_steps = (unsigned)atoi(argv[i+1]);
             opt->max_steps = min(7, opt->max_steps);
+            opt->max_steps = max(2, opt->max_steps);
             i += 2;
         } else if (0 == strcmp("--help", argv[i])) {
             help();


### PR DESCRIPTION
If imgmin is ran with max steps set to either 0 or 1, it will either fail with a cryptic error message (if 0), or just don't produce anything (if 1), so it makes sense to impose a lower limit of 2 steps.
