### PR TITLE
fix autoreconf errors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,10 +2,10 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.59])
-AC_INIT([imgmin], [0.7], [https://github.com/rflynn/imgmin/issues])
+AC_INIT([imgmin], [1.1], [https://github.com/rflynn/imgmin/issues])
 AC_CONFIG_SRCDIR([src])
 
-AM_INIT_AUTOMAKE([imgmin], [0.7])
+AM_INIT_AUTOMAKE([subdir-objects])
 
 AC_CONFIG_HEADERS([config.h])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,9 +5,9 @@ AM_LDLIBS = -lm
 bin_PROGRAMS = imgmin mod_imgmin
 imgmin_SOURCES = imgmin.c dssim.c
 
-imgmin: $(imgmin_SOURCES)
+imgmin$(EXEEXT): $(imgmin_SOURCES)
 	$(CC) $(AM_CFLAGS) $(AM_LDFLAGS) `$(MAGICK_CONFIG) --cflags --cppflags` -o $@ $^ `$(MAGICK_CONFIG) --ldflags --libs` $(AM_LDLIBS)
 
-mod_imgmin:
+mod_imgmin$(EXEEXT):
 	$(MAKE) -C apache2
 

--- a/src/apache2/Makefile.am
+++ b/src/apache2/Makefile.am
@@ -5,12 +5,12 @@
 bin_PROGRAMS = mod_imgmin_la
 mod_imgmin_la_SOURCES = mod_imgmin.c ../imgmin.c ../dssim.c
 
-mod_imgmin_la: $(mod_imgmin_la_SOURCES)
+mod_imgmin_la$(EXEEXT): $(mod_imgmin_la_SOURCES)
 	if [ "$(APXS)" != "" ]; then \
 		$(APXS) -I `pwd`/.. `$(MAGICK_CONFIG) --cppflags --ldflags --libs|xargs|sed "s/-fopenmp\s//"` -Wc,-DIMGMIN_LIB -Wc,-W -Wc,-Wall -Wc,-Wno-unused-parameter -c $(mod_imgmin_la_SOURCES); \
 	fi
 
-install-exec-local: mod_imgmin_la
+install-exec-local$(EXEEXT): mod_imgmin_la
 	if [ "$(APXS)" != "" ]; then \
 		$(APXS) -i -a mod_imgmin.la; \
 	fi


### PR DESCRIPTION
- add executable extensions
- new `AM_INIT_AUTOMAKE` syntax
- add right version (`1.1`)